### PR TITLE
#13 Remove 'default' device mention from README.md to correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Specify which device to display the VU meter on.
 
 Supported devices:
 
-* default (18-segment VU driven by SN3218)
 * blinkt - Simple amplitude meter through Green->Yellow->Red
 * phat-beat - Simple stereo amplitude meter
 * speaker-phat - Simple mono amplitude meter


### PR DESCRIPTION
As per https://github.com/pimoroni/pivumeter/issues/13#issuecomment-320905830 there is no current feature for generic SN3218