### PR TITLE
Tweaked asound.conf for Raspbian Stretch

### DIFF
--- a/dependencies/etc/asound.conf
+++ b/dependencies/etc/asound.conf
@@ -1,63 +1,38 @@
 pcm.!default {
-	type plug
-	slave.pcm {
-		type meter
-		slave.pcm "softvol"
-		scopes.0 pivumeter
-	}
+        type plug
+        slave.pcm "softvol_and_pivumeter"
 }
 
 ctl.!default {
-	type hw
-	card 0
-}
-
-pcm.dmixer {
-	type dmix
-	ipc_key 1024
-	ipc_perm 0666
-	slave.pcm 'hw:0,0'
-	slave {
-		period_time 0
-		period_size 1024
-		buffer_size 8192
-	}
-	bindings {
-		0 0
-		1 1
-	}
-}
-
-ctl.dmixer {
-	type hw
-	card 0
-}
-
-pcm.softvol {
-	type softvol
-	slave.pcm "dmixer"
-	control {
-		name "PCM"
-		card 0
-	}	
-}
-
-pcm_scope.pivumeter {
-	type pivumeter
-	decay_ms 500
-	peak_ms 400
-	brightness 128
-	output_device default
-}
-
-pcm_scope_type.pivumeter {
-	lib /usr/local/lib/libpivumeter.so
+        type hw
+        card 0
 }
 
 pcm.pivumeter {
-	type meter
-	slave.pcm 'hw:0,0'
-	scopes.0 pivumeter
+        type meter
+        slave.pcm "hw:0,0"
+        scopes.0 pivumeter
+}
+
+pcm.softvol_and_pivumeter {
+        type softvol
+        slave.pcm "pivumeter"
+        control {
+                name "PCM"
+                card 0
+        }
+}
+
+pcm_scope.pivumeter {
+        type pivumeter
+        decay_ms 500
+        peak_ms 400
+        brightness 128
+        output_device phat-beat
+}
+
+pcm_scope_type.pivumeter {
+        lib /usr/local/lib/libpivumeter.so
 }
 
 pcm.dsp0 pivumeter


### PR DESCRIPTION
This change fixes #16 by removing `dmix` from the configuration.